### PR TITLE
tweet repository and mapper settings, unit tests

### DIFF
--- a/src/main/java/clone/twitter/config/PersistenceConfig.java
+++ b/src/main/java/clone/twitter/config/PersistenceConfig.java
@@ -1,6 +1,8 @@
 package clone.twitter.config;
 
 import clone.twitter.repository.TweetMapper;
+import clone.twitter.repository.TweetRepository;
+import clone.twitter.repository.TweetRepositoryV1;
 import clone.twitter.repository.UserMapper;
 import clone.twitter.repository.UserRepository;
 import clone.twitter.repository.UserRepositoryV1;
@@ -19,5 +21,10 @@ public class PersistenceConfig {
     @Bean
     public UserRepository userRepository() {
         return new UserRepositoryV1(userMapper);
+    }
+
+    @Bean
+    public TweetRepository tweetRepository() {
+        return new TweetRepositoryV1(tweetMapper);
     }
 }

--- a/src/main/java/clone/twitter/repository/TweetMapper.java
+++ b/src/main/java/clone/twitter/repository/TweetMapper.java
@@ -9,9 +9,9 @@ import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface TweetMapper {
-    List<Tweet> findInitialTimelinePageTweets(@Param("id") String userid, @Param("limit") int limit);
+    List<Tweet> findInitialTimelinePageTweets(@Param("userId") String userId, @Param("limit") int limit);
 
-    List<Tweet> findNextTimelinePageTweets(@Param("id") String userid, @Param("createdAt") LocalDateTime createdAt, @Param("limit") int limit);
+    List<Tweet> findNextTimelinePageTweets(@Param("userId") String userId, @Param("createdAt") LocalDateTime createdAt, @Param("limit") int limit);
 
     Optional<Tweet> findById(String id);
 

--- a/src/main/java/clone/twitter/repository/TweetMapper.java
+++ b/src/main/java/clone/twitter/repository/TweetMapper.java
@@ -1,22 +1,21 @@
 package clone.twitter.repository;
 
 import clone.twitter.domain.Tweet;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface TweetMapper {
+    List<Tweet> findInitialTimelinePageTweets(@Param("id") String userid, @Param("limit") int limit);
 
-    List<Tweet> findAllByOrderByCreatedAtDesc();
+    List<Tweet> findNextTimelinePageTweets(@Param("id") String userid, @Param("createdAt") LocalDateTime createdAt, @Param("limit") int limit);
 
-    List<Tweet> findAllByUserIdByOrderByCreatedAtDesc(Long userId);
-
-    Optional<Tweet> findById(Long id);
+    Optional<Tweet> findById(String id);
 
     void save(Tweet tweet);
 
-    void deleteById(Long id);
-
-    void clear();
+    void deleteById(String id);
 }

--- a/src/main/java/clone/twitter/repository/TweetRepository.java
+++ b/src/main/java/clone/twitter/repository/TweetRepository.java
@@ -3,10 +3,8 @@ package clone.twitter.repository;
 import clone.twitter.domain.Tweet;
 import java.util.List;
 import java.util.Optional;
-import org.apache.ibatis.annotations.Mapper;
 
-@Mapper
-public interface TweetMapper {
+public interface TweetRepository {
 
     List<Tweet> findAllByOrderByCreatedAtDesc();
 
@@ -14,9 +12,7 @@ public interface TweetMapper {
 
     Optional<Tweet> findById(Long id);
 
-    void save(Tweet tweet);
+    Tweet save(Tweet tweet);
 
     void deleteById(Long id);
-
-    void clear();
 }

--- a/src/main/java/clone/twitter/repository/TweetRepository.java
+++ b/src/main/java/clone/twitter/repository/TweetRepository.java
@@ -1,18 +1,18 @@
 package clone.twitter.repository;
 
 import clone.twitter.domain.Tweet;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface TweetRepository {
+    List<Tweet> findInitialTimelinePageTweets(String userid);
 
-    List<Tweet> findAllByOrderByCreatedAtDesc();
+    List<Tweet> findNextTimelinePageTweets(String userid, LocalDateTime createdAt);
 
-    List<Tweet> findAllByUserIdByOrderByCreatedAtDesc(Long userId);
-
-    Optional<Tweet> findById(Long id);
+    Optional<Tweet> findById(String id);
 
     Tweet save(Tweet tweet);
 
-    void deleteById(Long id);
+    void deleteById(String id);
 }

--- a/src/main/java/clone/twitter/repository/TweetRepositoryV1.java
+++ b/src/main/java/clone/twitter/repository/TweetRepositoryV1.java
@@ -1,0 +1,75 @@
+package clone.twitter.repository;
+
+import clone.twitter.domain.Tweet;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Prototype v.1
+ * for tweet APIs
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class TweetRepositoryV1 implements TweetRepository {
+    private final TweetMapper tweetMapper;
+
+    /**
+     * for tweets on timeline board
+     * @return all tweets in descending order
+     */
+    @Override
+    public List<Tweet> findAllByOrderByCreatedAtDesc() {
+        return tweetMapper.findAllByOrderByCreatedAtDesc();
+    }
+
+    /**
+     * for tweets on user's profile page
+     * @param userId primary key of specific user account
+     * @return all tweets of a user in descending order
+     */
+    @Override
+    public List<Tweet> findAllByUserIdByOrderByCreatedAtDesc(Long userId) {
+        return tweetMapper.findAllByUserIdByOrderByCreatedAtDesc(userId);
+    }
+
+    /**
+     * this method is primarily for general internal operations.
+     * @param id primary key of a specific tweet
+     * @return a specific tweet matching the id
+     */
+    @Override
+    public Optional<Tweet> findById(Long id) {
+        return tweetMapper.findById(id);
+    }
+
+    /**
+     * for post api request
+     * @param tweet new tweet requested by the user
+     * @return complete information of the tweet posted by the user
+     */
+    @Override
+    public Tweet save(Tweet tweet) {
+        tweetMapper.save(tweet);
+        return tweet;
+    }
+
+    /**
+     * for delete request of a tweet
+     * @param id primary key of a specific tweet
+     */
+    @Override
+    public void deleteById(Long id) {
+        tweetMapper.deleteById(id);
+    }
+
+    /**
+     * for internal test only
+     */
+    public void clear() {
+        tweetMapper.clear();
+    }
+}

--- a/src/main/java/clone/twitter/repository/TweetRepositoryV1.java
+++ b/src/main/java/clone/twitter/repository/TweetRepositoryV1.java
@@ -20,7 +20,7 @@ public class TweetRepositoryV1 implements TweetRepository {
     /**
      * pagination 시 한 번에 로드되는 트윗의 개수을 지정합니다.
      */
-    private static final int TWEET_LOAD_LIMIT = 3;
+    private static final int TWEET_LOAD_LIMIT = 5;
 
     /**
      * 타임라인에 처음 접근했을 시 고정된 수의 트윗을 불러옵니다.

--- a/src/main/java/clone/twitter/repository/TweetRepositoryV1.java
+++ b/src/main/java/clone/twitter/repository/TweetRepositoryV1.java
@@ -1,6 +1,7 @@
 package clone.twitter.repository;
 
 import clone.twitter.domain.Tweet;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -8,8 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 /**
- * Prototype v.1
- * for tweet APIs
+ * Prototype v.1 for tweet APIs.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -18,22 +18,27 @@ public class TweetRepositoryV1 implements TweetRepository {
     private final TweetMapper tweetMapper;
 
     /**
-     * for tweets on timeline board
-     * @return all tweets in descending order
+     * pagination 시 한 번에 로드되는 트윗의 개수을 지정합니다.
      */
-    @Override
-    public List<Tweet> findAllByOrderByCreatedAtDesc() {
-        return tweetMapper.findAllByOrderByCreatedAtDesc();
+    private static final int TWEET_LOAD_LIMIT = 3;
+
+    /**
+     * 타임라인에 처음 접근했을 시 고정된 수의 트윗을 불러옵니다.
+     * @param userid 타임라인을 조회하려는 유저의 아이디
+     * @return 유저 자신 및 자신이 팔로우하는 유저가 생성한 특정 수의 트윗 목록. 생성일자 기준 최근부터 내림차순으로 정렬되어 있습니다.
+     */
+    public List<Tweet> findInitialTimelinePageTweets(String userid) {
+        return tweetMapper.findInitialTimelinePageTweets(userid, TWEET_LOAD_LIMIT);
     }
 
     /**
-     * for tweets on user's profile page
-     * @param userId primary key of specific user account
-     * @return all tweets of a user in descending order
+     * 타임라인을 스크롤 다운하여 이전에 불러온 트윗 목록의 마지막 트윗에 도달했을 때, 고정된 수의 트윗을 추가로 불러옵니다.
+     * @param userid 타임라인을 조회중인 유저의 아이디
+     * @param createdAt 이전에 불러온 트윗 목록 중 마지막 트윗의 생성일자
+     * @return 유저 자신 및 자신이 팔로우하는 유저가 생성한 특정 수의 트윗 목록. 이전에 불러온 마지막 트윗 생성일자 이후부터 생성일자 기준 내림차순으로 정렬되어 있습니다.
      */
-    @Override
-    public List<Tweet> findAllByUserIdByOrderByCreatedAtDesc(Long userId) {
-        return tweetMapper.findAllByUserIdByOrderByCreatedAtDesc(userId);
+    public List<Tweet> findNextTimelinePageTweets(String userid, LocalDateTime createdAt) {
+        return tweetMapper.findNextTimelinePageTweets(userid, createdAt, TWEET_LOAD_LIMIT);
     }
 
     /**
@@ -42,7 +47,7 @@ public class TweetRepositoryV1 implements TweetRepository {
      * @return a specific tweet matching the id
      */
     @Override
-    public Optional<Tweet> findById(Long id) {
+    public Optional<Tweet> findById(String id) {
         return tweetMapper.findById(id);
     }
 
@@ -62,14 +67,7 @@ public class TweetRepositoryV1 implements TweetRepository {
      * @param id primary key of a specific tweet
      */
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(String id) {
         tweetMapper.deleteById(id);
-    }
-
-    /**
-     * for internal test only
-     */
-    public void clear() {
-        tweetMapper.clear();
     }
 }

--- a/src/main/resources/clone.twitter.repository/TweetMapper.xml
+++ b/src/main/resources/clone.twitter.repository/TweetMapper.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="clone.twitter.repository.TweetMapper">
-
-</mapper>

--- a/src/main/resources/mapper/TweetMapper.xml
+++ b/src/main/resources/mapper/TweetMapper.xml
@@ -5,12 +5,13 @@
   <select id="findInitialTimelinePageTweets" resultType="Tweet">
     SELECT *
     FROM tweet
-    WHERE user_id IN (
-      SELECT followee_id
-      FROM follow
-      WHERE follower_id = #{userId}
+    WHERE (user_id IN (
+    SELECT followee_id
+    FROM follow
+    WHERE follower_id = #{userId}
     )
-    AND user_id = #{userId}
+    OR user_id = #{userId}
+    )
     ORDER BY created_at DESC
     LIMIT #{limit}
   </select>
@@ -18,12 +19,13 @@
   <select id="findNextTimelinePageTweets" resultType="Tweet">
     SELECT *
     FROM tweet
-    WHERE user_id IN (
-      SELECT followee_id
-      FROM follow
-      WHERE follower_id = #{userId}
+    WHERE (user_id IN (
+    SELECT followee_id
+    FROM follow
+    WHERE follower_id = #{userId}
     )
-    AND user_id = #{userId}
+    OR user_id = #{userId}
+    )
     AND created_at &lt; #{createdAt}
     ORDER BY created_at DESC
     LIMIT #{limit}

--- a/src/main/resources/mapper/TweetMapper.xml
+++ b/src/main/resources/mapper/TweetMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="clone.twitter.repository.TweetMapper">
+
+  <select id="findAllByOrderByCreatedAtDesc" resultType="Tweet">
+    SELECT id, text, user_id, created_at
+    FROM tweet
+    ORDER BY created_at DESC;
+  </select>
+
+  <select id="findAllByUserIdByOrderByCreatedAtDesc" resultType="Tweet">
+    SELECT id, text, user_id, created_at
+    FROM tweet
+    WHERE user_id = #{userId}
+    ORDER BY created_at DESC;
+  </select>
+
+  <select id="findById" resultType="Tweet">
+    SELECT id, text, user_id, created_at
+    FROM tweet
+    where id = #{id}
+  </select>
+
+  <insert id="save" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO tweet (text, user_id, created_at)
+    VALUES (#{text}, #{userId}, #{createdAt})
+  </insert>
+
+  <delete id="deleteById">
+    DELETE FROM tweet
+    WHERE id = #{id}
+  </delete>
+
+  <delete id="clear">
+    DELETE FROM tweet
+  </delete>
+</mapper>

--- a/src/main/resources/mapper/TweetMapper.xml
+++ b/src/main/resources/mapper/TweetMapper.xml
@@ -2,18 +2,31 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="clone.twitter.repository.TweetMapper">
-
-  <select id="findAllByOrderByCreatedAtDesc" resultType="Tweet">
-    SELECT id, text, user_id, created_at
+  <select id="findInitialTimelinePageTweets" resultType="Tweet">
+    SELECT *
     FROM tweet
-    ORDER BY created_at DESC;
+    WHERE user_id IN (
+      SELECT followee_id
+      FROM follow
+      WHERE follower_id = #{userId}
+    )
+    AND user_id = #{userId}
+    ORDER BY created_at DESC
+    LIMIT #{limit}
   </select>
 
-  <select id="findAllByUserIdByOrderByCreatedAtDesc" resultType="Tweet">
-    SELECT id, text, user_id, created_at
+  <select id="findNextTimelinePageTweets" resultType="Tweet">
+    SELECT *
     FROM tweet
-    WHERE user_id = #{userId}
-    ORDER BY created_at DESC;
+    WHERE user_id IN (
+      SELECT followee_id
+      FROM follow
+      WHERE follower_id = #{userId}
+    )
+    AND user_id = #{userId}
+    AND created_at &lt; #{createdAt}
+    ORDER BY created_at DESC
+    LIMIT #{limit}
   </select>
 
   <select id="findById" resultType="Tweet">
@@ -22,17 +35,13 @@
     where id = #{id}
   </select>
 
-  <insert id="save" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO tweet (text, user_id, created_at)
-    VALUES (#{text}, #{userId}, #{createdAt})
+  <insert id="save">
+    INSERT INTO tweet (id, text, user_id, created_at)
+    VALUES (#{id, jdbcType=CHAR}, #{text}, #{userId}, #{createdAt})
   </insert>
 
   <delete id="deleteById">
     DELETE FROM tweet
     WHERE id = #{id}
-  </delete>
-
-  <delete id="clear">
-    DELETE FROM tweet
   </delete>
 </mapper>

--- a/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
+++ b/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
@@ -2,11 +2,17 @@ package clone.twitter.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import clone.twitter.repository.FollowRepository;
 import clone.twitter.repository.TweetRepository;
 import clone.twitter.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +34,9 @@ class TweetRepositoryTest {
     UserRepository userRepository;
 
     @Autowired
+    FollowRepository followRepository;
+
+    @Autowired
     PlatformTransactionManager transactionManager;
 
     TransactionStatus status;
@@ -44,12 +53,248 @@ class TweetRepositoryTest {
 
     @Test
     void findInitialTimelinePageTweets() {
-        // 테스트 선행조건: user repository + follow repository 구현
+        // given
+        // 유저 생성
+        User user1 = new User("user1", "user1@gmail.com", "AAAAAA", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "BBBBBB", "user2ProfileName", LocalDate.of(1992, 2, 2));
+        User user3 = new User("user3", "user3@gmail.com", "CCCCCC", "user3ProfileName", LocalDate.of(1993, 3, 3));
+        User user4 = new User("user4", "user4@gmail.com", "DDDDDD", "user4ProfileName", LocalDate.of(1994, 4, 4));
+        User user5 = new User("user5", "user5@gmail.com", "EEEEEE", "user5ProfileName", LocalDate.of(1995, 5, 5));
+
+        // 팔로우 생성 user1 -> user2, user3
+        Follow follow1 = new Follow(user1.getId(), user2.getId());
+        Follow follow2 = new Follow(user1.getId(), user3.getId());
+
+        // 팔로우 생성 user2 -> user3, user4
+        Follow follow3 = new Follow(user2.getId(), user3.getId());
+        Follow follow4 = new Follow(user2.getId(), user4.getId());
+
+        // 팔로우 생성 user3 -> user4, user5
+        Follow follow5 = new Follow(user3.getId(), user4.getId());
+        Follow follow6 = new Follow(user3.getId(), user5.getId());
+
+        // 팔로우 생성 user4 -> user5, user1
+        Follow follow7 = new Follow(user4.getId(), user5.getId());
+        Follow follow8 = new Follow(user4.getId(), user1.getId());
+
+        // 팔로우 생성 user5 -> user1, user2
+        Follow follow9 = new Follow(user5.getId(), user1.getId());
+        Follow follow10 = new Follow(user5.getId(), user2.getId());
+
+        // 유저별 트윗1 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet3 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 3).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet4 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 4).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet5 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 5).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗2 생성
+        Tweet tweet6 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 6).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet7 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 7).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet8 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 8).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet9 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 9).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet10 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 10).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗3 생성
+        Tweet tweet11 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 11).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet12 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 12).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet13 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 13).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet14 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 14).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet15 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 15).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗4 생성
+        Tweet tweet16 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 16).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet17 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 17).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet18 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 18).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet19 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 19).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet20 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 20).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗5 생성
+        Tweet tweet21 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 21).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet22 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 22).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet23 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 23).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet24 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 24).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet25 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 25).truncatedTo(ChronoUnit.SECONDS));
+
+        // when
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+        userRepository.save(user5);
+
+        followRepository.follow(follow1);
+        followRepository.follow(follow2);
+        followRepository.follow(follow3);
+        followRepository.follow(follow4);
+        followRepository.follow(follow5);
+        followRepository.follow(follow6);
+        followRepository.follow(follow7);
+        followRepository.follow(follow8);
+        followRepository.follow(follow9);
+        followRepository.follow(follow10);
+
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet2);
+        tweetRepository.save(tweet3);
+        tweetRepository.save(tweet4);
+        tweetRepository.save(tweet5);
+        tweetRepository.save(tweet6);
+        tweetRepository.save(tweet7);
+        tweetRepository.save(tweet8);
+        tweetRepository.save(tweet9);
+        tweetRepository.save(tweet10);
+        tweetRepository.save(tweet11);
+        tweetRepository.save(tweet12);
+        tweetRepository.save(tweet13);
+        tweetRepository.save(tweet14);
+        tweetRepository.save(tweet15);
+        tweetRepository.save(tweet16);
+        tweetRepository.save(tweet17);
+        tweetRepository.save(tweet18);
+        tweetRepository.save(tweet19);
+        tweetRepository.save(tweet20);
+        tweetRepository.save(tweet21);
+        tweetRepository.save(tweet22);
+        tweetRepository.save(tweet23);
+        tweetRepository.save(tweet24);
+        tweetRepository.save(tweet25);
+
+        // then
+        List<Tweet> initialTimelinePageTweetsForUser1 = tweetRepository.findInitialTimelinePageTweets(user1.getId());
+        List<Tweet> initialTimelinePageTweetsForUser2 = tweetRepository.findInitialTimelinePageTweets(user2.getId());
+        List<Tweet> initialTimelinePageTweetsForUser3 = tweetRepository.findInitialTimelinePageTweets(user3.getId());
+        List<Tweet> initialTimelinePageTweetsForUser4 = tweetRepository.findInitialTimelinePageTweets(user4.getId());
+        List<Tweet> initialTimelinePageTweetsForUser5 = tweetRepository.findInitialTimelinePageTweets(user5.getId());
+
+        Assertions.assertThat(initialTimelinePageTweetsForUser1).containsExactly(tweet23, tweet22, tweet21, tweet18, tweet17);
+        Assertions.assertThat(initialTimelinePageTweetsForUser2).containsExactly(tweet24, tweet23, tweet22, tweet19, tweet18);
+        Assertions.assertThat(initialTimelinePageTweetsForUser3).containsExactly(tweet25, tweet24, tweet23, tweet20, tweet19);
+        Assertions.assertThat(initialTimelinePageTweetsForUser4).containsExactly(tweet25, tweet24, tweet21, tweet20, tweet19);
+        Assertions.assertThat(initialTimelinePageTweetsForUser5).containsExactly(tweet25, tweet22, tweet21, tweet20, tweet17);
     }
 
     @Test
     void findNextTimelinePageTweets() {
-        // 테스트 선행조건: user repository + follow repository 구현
+        // given
+        // 유저 생성
+        User user1 = new User("user1", "user1@gmail.com", "AAAAAA", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "BBBBBB", "user2ProfileName", LocalDate.of(1992, 2, 2));
+        User user3 = new User("user3", "user3@gmail.com", "CCCCCC", "user3ProfileName", LocalDate.of(1993, 3, 3));
+        User user4 = new User("user4", "user4@gmail.com", "DDDDDD", "user4ProfileName", LocalDate.of(1994, 4, 4));
+        User user5 = new User("user5", "user5@gmail.com", "EEEEEE", "user5ProfileName", LocalDate.of(1995, 5, 5));
+
+        // 팔로우 생성 user1 -> user2, user3
+        Follow follow1 = new Follow(user1.getId(), user2.getId());
+        Follow follow2 = new Follow(user1.getId(), user3.getId());
+
+        // 팔로우 생성 user2 -> user3, user4
+        Follow follow3 = new Follow(user2.getId(), user3.getId());
+        Follow follow4 = new Follow(user2.getId(), user4.getId());
+
+        // 팔로우 생성 user3 -> user4, user5
+        Follow follow5 = new Follow(user3.getId(), user4.getId());
+        Follow follow6 = new Follow(user3.getId(), user5.getId());
+
+        // 팔로우 생성 user4 -> user5, user1
+        Follow follow7 = new Follow(user4.getId(), user5.getId());
+        Follow follow8 = new Follow(user4.getId(), user1.getId());
+
+        // 팔로우 생성 user5 -> user1, user2
+        Follow follow9 = new Follow(user5.getId(), user1.getId());
+        Follow follow10 = new Follow(user5.getId(), user2.getId());
+
+        // 유저별 트윗1 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet3 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 3).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet4 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 4).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet5 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet1 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 5).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗2 생성
+        Tweet tweet6 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 6).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet7 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 7).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet8 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 8).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet9 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 9).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet10 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet2 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 10).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗3 생성
+        Tweet tweet11 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 11).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet12 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 12).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet13 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 13).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet14 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 14).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet15 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet3 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 15).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗4 생성
+        Tweet tweet16 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 16).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet17 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 17).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet18 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 18).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet19 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 19).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet20 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet4 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 20).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저별 트윗5 생성
+        Tweet tweet21 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 21).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet22 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 22).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet23 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user3", user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 23).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet24 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user4", user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 24).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet25 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet5 of user5", user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 25).truncatedTo(ChronoUnit.SECONDS));
+
+        // when
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+        userRepository.save(user5);
+
+        followRepository.follow(follow1);
+        followRepository.follow(follow2);
+        followRepository.follow(follow3);
+        followRepository.follow(follow4);
+        followRepository.follow(follow5);
+        followRepository.follow(follow6);
+        followRepository.follow(follow7);
+        followRepository.follow(follow8);
+        followRepository.follow(follow9);
+        followRepository.follow(follow10);
+
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet2);
+        tweetRepository.save(tweet3);
+        tweetRepository.save(tweet4);
+        tweetRepository.save(tweet5);
+        tweetRepository.save(tweet6);
+        tweetRepository.save(tweet7);
+        tweetRepository.save(tweet8);
+        tweetRepository.save(tweet9);
+        tweetRepository.save(tweet10);
+        tweetRepository.save(tweet11);
+        tweetRepository.save(tweet12);
+        tweetRepository.save(tweet13);
+        tweetRepository.save(tweet14);
+        tweetRepository.save(tweet15);
+        tweetRepository.save(tweet16);
+        tweetRepository.save(tweet17);
+        tweetRepository.save(tweet18);
+        tweetRepository.save(tweet19);
+        tweetRepository.save(tweet20);
+        tweetRepository.save(tweet21);
+        tweetRepository.save(tweet22);
+        tweetRepository.save(tweet23);
+        tweetRepository.save(tweet24);
+        tweetRepository.save(tweet25);
+
+        // then
+        List<Tweet> nextTimelinePageTweetsForUser1 = tweetRepository.findNextTimelinePageTweets(user1.getId(), tweet17.getCreatedAt());
+        List<Tweet> nextTimelinePageTweetsForUser2 = tweetRepository.findNextTimelinePageTweets(user2.getId(), tweet18.getCreatedAt());
+        List<Tweet> nextTimelinePageTweetsForUser3 = tweetRepository.findNextTimelinePageTweets(user3.getId(), tweet19.getCreatedAt());
+        List<Tweet> nextTimelinePageTweetsForUser4 = tweetRepository.findNextTimelinePageTweets(user4.getId(), tweet20.getCreatedAt());
+        List<Tweet> nextTimelinePageTweetsForUser5 = tweetRepository.findNextTimelinePageTweets(user5.getId(), tweet17.getCreatedAt());
+
+        Assertions.assertThat(nextTimelinePageTweetsForUser1).containsExactly(tweet16, tweet13, tweet12, tweet11, tweet8);
+        Assertions.assertThat(nextTimelinePageTweetsForUser2).containsExactly(tweet17, tweet14, tweet13, tweet12, tweet9);
+        Assertions.assertThat(nextTimelinePageTweetsForUser3).containsExactly(tweet18, tweet15, tweet14, tweet13, tweet10);
+        Assertions.assertThat(nextTimelinePageTweetsForUser4).containsExactly(tweet19, tweet16, tweet15, tweet14, tweet11);
+        Assertions.assertThat(nextTimelinePageTweetsForUser5).containsExactly(tweet16, tweet15, tweet12, tweet11, tweet10);
     }
 
     @Test
@@ -129,5 +374,9 @@ class TweetRepositoryTest {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+    }
+
+    int calculate(int n, int m) {
+        return (n - 1) % m + 1;
     }
 }

--- a/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
+++ b/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
@@ -367,16 +367,4 @@ class TweetRepositoryTest {
 
         assertThat(foundTweet3).isEqualTo(Optional.of(savedTweet3));
     }
-
-    private static void sleep(int millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-
-    int calculate(int n, int m) {
-        return (n - 1) % m + 1;
-    }
 }

--- a/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
+++ b/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
@@ -3,156 +3,59 @@ package clone.twitter.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import clone.twitter.repository.TweetRepository;
-import clone.twitter.repository.TweetRepositoryV1;
 import clone.twitter.repository.UserRepository;
-import clone.twitter.repository.UserRepositoryV1;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 @Slf4j
 @Transactional
 @SpringBootTest
 class TweetRepositoryTest {
-
     @Autowired
     TweetRepository tweetRepository;
 
     @Autowired
     UserRepository userRepository;
 
+    @Autowired
+    PlatformTransactionManager transactionManager;
+
+    TransactionStatus status;
+
+    @BeforeEach
+    void beforeEach() {
+        status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+    }
+
     @AfterEach
     void afterEach() {
-
-        if (tweetRepository instanceof TweetRepositoryV1) {
-            ((TweetRepositoryV1) tweetRepository).clear();
-        }
-
-        if (userRepository instanceof UserRepositoryV1) {
-            ((UserRepositoryV1) userRepository).clear();
-        }
+        transactionManager.rollback(status);
     }
 
     @Test
-    void findAllByOrderByCreatedAtDesc() {
-
-        //given
-        User user = new User(
-            "haro123",
-            "haro@gmail.com",
-            "b03b29",
-            "haro",
-            LocalDate.of(1999, 9, 9)
-        );
-
-        userRepository.save(user);
-
-        Tweet tweet1 = new Tweet("this be testing1", user.getId());
-        sleep(1000);
-        Tweet tweet2 = new Tweet("this be testing2", user.getId());
-        sleep(1000);
-        Tweet tweet3 = new Tweet("this be testing3", user.getId());
-
-        //when
-        List<Tweet> savedTweets = new ArrayList<>();
-
-        savedTweets.add(tweetRepository.save(tweet3));
-        savedTweets.add(tweetRepository.save(tweet2));
-        savedTweets.add(tweetRepository.save(tweet1));
-
-        //then
-        List<Tweet> foundTweets = tweetRepository.findAllByOrderByCreatedAtDesc();
-
-        assertThat(foundTweets).isEqualTo(savedTweets);
+    void findInitialTimelinePageTweets() {
+        // 테스트 선행조건: user repository + follow repository 구현
     }
 
     @Test
-    void findAllByUserIdByOrderByCreatedAtDesc() {
-
-        //given
-        User user1 = new User(
-            "haro123",
-            "haro@gmail.com",
-            "b03b29",
-            "haro",
-            LocalDate.of(1999, 9, 9)
-        );
-
-        User user2 = new User(
-            "hello123",
-            "hello@gmail.com",
-            "e14c28",
-            "hello",
-            LocalDate.of(1998, 8, 8)
-        );
-
-        User user3 = new User(
-            "bonjour123",
-            "bonjour@gmail.com",
-            "1d052e",
-            "bonjour",
-            LocalDate.of(1997, 7, 7)
-        );
-
-        userRepository.save(user1);
-        userRepository.save(user2);
-        userRepository.save(user3);
-
-        Tweet tweet1 = new Tweet("hello, this be testing1", user2.getId());
-        sleep(1000);
-        Tweet tweet2 = new Tweet("bonjour, this be testing1", user3.getId());
-        sleep(1000);
-        Tweet tweet3 = new Tweet("haro, this be testing1", user1.getId());
-        sleep(1000);
-        Tweet tweet4 = new Tweet("hello, this be testing2", user2.getId());
-        sleep(1000);
-        Tweet tweet5 = new Tweet("bonjour, this be testing2", user3.getId());
-        sleep(1000);
-        Tweet tweet6 = new Tweet("haro, this be testing2", user1.getId());
-        sleep(1000);
-        Tweet tweet7 = new Tweet("hello, this be testing3", user2.getId());
-        sleep(1000);
-        Tweet tweet8 = new Tweet("bonjour, this be testing3", user3.getId());
-        sleep(1000);
-        Tweet tweet9 = new Tweet("haro, this be testing3", user1.getId());
-
-        //when
-        List<Tweet> TweetsSavedByUser3 = new ArrayList<>();
-
-        tweetRepository.save(tweet9);
-        tweetRepository.save(tweet7);
-        tweetRepository.save(tweet6);
-        tweetRepository.save(tweet4);
-        tweetRepository.save(tweet3);
-        tweetRepository.save(tweet1);
-
-        TweetsSavedByUser3.add(tweetRepository.save(tweet8));
-        TweetsSavedByUser3.add(tweetRepository.save(tweet5));
-        TweetsSavedByUser3.add(tweetRepository.save(tweet2));
-
-        //then
-        List<Tweet> foundTweetsOfUser3 = tweetRepository.findAllByUserIdByOrderByCreatedAtDesc(
-            user3.getId());
-
-        assertThat(foundTweetsOfUser3).isEqualTo(TweetsSavedByUser3);
+    void findNextTimelinePageTweets() {
+        // 테스트 선행조건: user repository + follow repository 구현
     }
 
     @Test
     void findById() {
         //given
-        User user = new User(
-            "haro123",
-            "haro@gmail.com",
-            "b03b29", "haro",
-            LocalDate.of(1999, 9, 9)
-        );
+        User user = new User("haro123", "haro@gmail.com", "b03b29", "haro", LocalDate.of(1999, 9, 9));
 
         userRepository.save(user);
 
@@ -163,6 +66,7 @@ class TweetRepositoryTest {
         //when
         tweetRepository.save(tweet1);
         tweetRepository.save(tweet3);
+
         Tweet archivedTweet = tweetRepository.save(tweet2);
 
         //then
@@ -174,12 +78,7 @@ class TweetRepositoryTest {
     @Test
     void save() {
         //given
-        User user = new User(
-            "haro123",
-            "haro@gmail.com",
-            "b03b29", "haro",
-            LocalDate.of(1999, 9, 9)
-        );
+        User user = new User("haro123", "haro@gmail.com", "b03b29", "haro", LocalDate.of(1999, 9, 9));
 
         userRepository.save(user);
 
@@ -196,14 +95,8 @@ class TweetRepositoryTest {
 
     @Test
     void deleteById() {
-
         //given
-        User user = new User(
-            "haro123",
-            "haro@gmail.com",
-            "b03b29", "haro",
-            LocalDate.of(1999, 9, 9)
-        );
+        User user = new User("haro123", "haro@gmail.com", "b03b29", "haro", LocalDate.of(1999, 9, 9));
 
         userRepository.save(user);
 
@@ -224,7 +117,9 @@ class TweetRepositoryTest {
         Optional<Tweet> foundTweet3 = tweetRepository.findById(savedTweet3.getId());
 
         assertThat(foundTweet1).isEqualTo(Optional.of(savedTweet1));
+
         assertThat(foundTweet2).isEmpty();
+
         assertThat(foundTweet3).isEqualTo(Optional.of(savedTweet3));
     }
 

--- a/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
+++ b/src/test/java/clone/twitter/domain/TweetRepositoryTest.java
@@ -1,0 +1,238 @@
+package clone.twitter.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import clone.twitter.repository.TweetRepository;
+import clone.twitter.repository.TweetRepositoryV1;
+import clone.twitter.repository.UserRepository;
+import clone.twitter.repository.UserRepositoryV1;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+class TweetRepositoryTest {
+
+    @Autowired
+    TweetRepository tweetRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @AfterEach
+    void afterEach() {
+
+        if (tweetRepository instanceof TweetRepositoryV1) {
+            ((TweetRepositoryV1) tweetRepository).clear();
+        }
+
+        if (userRepository instanceof UserRepositoryV1) {
+            ((UserRepositoryV1) userRepository).clear();
+        }
+    }
+
+    @Test
+    void findAllByOrderByCreatedAtDesc() {
+
+        //given
+        User user = new User(
+            "haro123",
+            "haro@gmail.com",
+            "b03b29",
+            "haro",
+            LocalDate.of(1999, 9, 9)
+        );
+
+        userRepository.save(user);
+
+        Tweet tweet1 = new Tweet("this be testing1", user.getId());
+        sleep(1000);
+        Tweet tweet2 = new Tweet("this be testing2", user.getId());
+        sleep(1000);
+        Tweet tweet3 = new Tweet("this be testing3", user.getId());
+
+        //when
+        List<Tweet> savedTweets = new ArrayList<>();
+
+        savedTweets.add(tweetRepository.save(tweet3));
+        savedTweets.add(tweetRepository.save(tweet2));
+        savedTweets.add(tweetRepository.save(tweet1));
+
+        //then
+        List<Tweet> foundTweets = tweetRepository.findAllByOrderByCreatedAtDesc();
+
+        assertThat(foundTweets).isEqualTo(savedTweets);
+    }
+
+    @Test
+    void findAllByUserIdByOrderByCreatedAtDesc() {
+
+        //given
+        User user1 = new User(
+            "haro123",
+            "haro@gmail.com",
+            "b03b29",
+            "haro",
+            LocalDate.of(1999, 9, 9)
+        );
+
+        User user2 = new User(
+            "hello123",
+            "hello@gmail.com",
+            "e14c28",
+            "hello",
+            LocalDate.of(1998, 8, 8)
+        );
+
+        User user3 = new User(
+            "bonjour123",
+            "bonjour@gmail.com",
+            "1d052e",
+            "bonjour",
+            LocalDate.of(1997, 7, 7)
+        );
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+
+        Tweet tweet1 = new Tweet("hello, this be testing1", user2.getId());
+        sleep(1000);
+        Tweet tweet2 = new Tweet("bonjour, this be testing1", user3.getId());
+        sleep(1000);
+        Tweet tweet3 = new Tweet("haro, this be testing1", user1.getId());
+        sleep(1000);
+        Tweet tweet4 = new Tweet("hello, this be testing2", user2.getId());
+        sleep(1000);
+        Tweet tweet5 = new Tweet("bonjour, this be testing2", user3.getId());
+        sleep(1000);
+        Tweet tweet6 = new Tweet("haro, this be testing2", user1.getId());
+        sleep(1000);
+        Tweet tweet7 = new Tweet("hello, this be testing3", user2.getId());
+        sleep(1000);
+        Tweet tweet8 = new Tweet("bonjour, this be testing3", user3.getId());
+        sleep(1000);
+        Tweet tweet9 = new Tweet("haro, this be testing3", user1.getId());
+
+        //when
+        List<Tweet> TweetsSavedByUser3 = new ArrayList<>();
+
+        tweetRepository.save(tweet9);
+        tweetRepository.save(tweet7);
+        tweetRepository.save(tweet6);
+        tweetRepository.save(tweet4);
+        tweetRepository.save(tweet3);
+        tweetRepository.save(tweet1);
+
+        TweetsSavedByUser3.add(tweetRepository.save(tweet8));
+        TweetsSavedByUser3.add(tweetRepository.save(tweet5));
+        TweetsSavedByUser3.add(tweetRepository.save(tweet2));
+
+        //then
+        List<Tweet> foundTweetsOfUser3 = tweetRepository.findAllByUserIdByOrderByCreatedAtDesc(
+            user3.getId());
+
+        assertThat(foundTweetsOfUser3).isEqualTo(TweetsSavedByUser3);
+    }
+
+    @Test
+    void findById() {
+        //given
+        User user = new User(
+            "haro123",
+            "haro@gmail.com",
+            "b03b29", "haro",
+            LocalDate.of(1999, 9, 9)
+        );
+
+        userRepository.save(user);
+
+        Tweet tweet1 = new Tweet("haro, this be testing1", user.getId());
+        Tweet tweet2 = new Tweet("haro, this be testing2", user.getId());
+        Tweet tweet3 = new Tweet("haro, this be testing3", user.getId());
+
+        //when
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet3);
+        Tweet archivedTweet = tweetRepository.save(tweet2);
+
+        //then
+        Optional<Tweet> foundTweet = tweetRepository.findById(archivedTweet.getId());
+
+        assertThat(foundTweet).isEqualTo(Optional.of(archivedTweet));
+    }
+
+    @Test
+    void save() {
+        //given
+        User user = new User(
+            "haro123",
+            "haro@gmail.com",
+            "b03b29", "haro",
+            LocalDate.of(1999, 9, 9)
+        );
+
+        userRepository.save(user);
+
+        Tweet tweet = new Tweet("this be testing", user.getId());
+
+        //when
+        Tweet savedTweet = tweetRepository.save(tweet);
+
+        //then
+        Optional<Tweet> foundTweet = tweetRepository.findById(tweet.getId());
+
+        assertThat(foundTweet).isEqualTo(Optional.of(savedTweet));
+    }
+
+    @Test
+    void deleteById() {
+
+        //given
+        User user = new User(
+            "haro123",
+            "haro@gmail.com",
+            "b03b29", "haro",
+            LocalDate.of(1999, 9, 9)
+        );
+
+        userRepository.save(user);
+
+        Tweet tweet1 = new Tweet("haro, this be testing1", user.getId());
+        Tweet tweet2 = new Tweet("haro, this be testing2", user.getId());
+        Tweet tweet3 = new Tweet("haro, this be testing3", user.getId());
+
+        //when
+        Tweet savedTweet1 = tweetRepository.save(tweet1);
+        Tweet savedTweet2 = tweetRepository.save(tweet2);
+        Tweet savedTweet3 = tweetRepository.save(tweet3);
+
+        tweetRepository.deleteById(tweet2.getId());
+
+        //then
+        Optional<Tweet> foundTweet1 = tweetRepository.findById(savedTweet1.getId());
+        Optional<Tweet> foundTweet2 = tweetRepository.findById(savedTweet2.getId());
+        Optional<Tweet> foundTweet3 = tweetRepository.findById(savedTweet3.getId());
+
+        assertThat(foundTweet1).isEqualTo(Optional.of(savedTweet1));
+        assertThat(foundTweet2).isEmpty();
+        assertThat(foundTweet3).isEqualTo(Optional.of(savedTweet3));
+    }
+
+    private static void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
# 최신 현황
* 구현 완료 기능 목록
  * 트윗 포스팅
  * 트윗 삭제
  * 트윗 id로 트윗 찾기
  * 타임라인 트윗 목록 불러오기 pagination
* 유닛 테스트 완료

## 초기 정보
* tweet api에 필요한 기초 tweet 리포지토리 기능, 마이바티스 매핑 정보, 테스트 코드를 작성하였습니다.
* 혹시 이후에 JPA로도 변경할 수 있도록 repository layer를 인터페이스와 구현부로 나누어 구현하였습니다.

## deprecated
- (삭제)기존 모든 트윗을 불러오는 메서드