### PR TITLE
[#14] like-tweet repository & unit test

### DIFF
--- a/src/main/java/clone/twitter/repository/LikeTweetMapper.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetMapper.java
@@ -1,0 +1,27 @@
+package clone.twitter.repository;
+
+import clone.twitter.domain.LikeTweet;
+import clone.twitter.domain.User;
+import java.util.List;
+import java.util.Optional;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface LikeTweetMapper {
+    void likeTweet(LikeTweet likeTweet);
+
+    void unlikeTweet(@Param("tweetId") String tweetId, @Param("userId") String userId);
+
+    Integer isLikedTweet(@Param("tweetId") String tweetId, @Param("userId") String userId);
+
+    List<User> findUsersLikedTweet(@Param("tweetId") String tweetId, @Param("limit") int limit);
+
+    List<User> findMoreUsersLikedTweet(@Param("tweetId") String tweetId, @Param("userId") String userId, @Param("limit") int limit);
+
+    /**
+     * @deprecated for test purpose only
+     */
+    @Deprecated
+    Optional<LikeTweet> findLikeTweet(@Param("tweetId") String tweetId, @Param("userId") String userId);
+}

--- a/src/main/java/clone/twitter/repository/LikeTweetMapper.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetMapper.java
@@ -13,8 +13,6 @@ public interface LikeTweetMapper {
 
     void unlikeTweet(@Param("tweetId") String tweetId, @Param("userId") String userId);
 
-    Integer isLikedTweet(@Param("tweetId") String tweetId, @Param("userId") String userId);
-
     List<User> findUsersLikedTweet(@Param("tweetId") String tweetId, @Param("limit") int limit);
 
     List<User> findMoreUsersLikedTweet(@Param("tweetId") String tweetId, @Param("userId") String userId, @Param("limit") int limit);

--- a/src/main/java/clone/twitter/repository/LikeTweetRepository.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetRepository.java
@@ -9,8 +9,6 @@ public interface LikeTweetRepository {
 
     void deleteByTweetIdAndUserId(String tweetId, String userId);
 
-    Integer existsByTweetIdAndUserId(String tweetId, String userId);
-
     List<User> findUsersByTweetIdOrderByCreatedAtDesc(String tweetId);
 
     List<User> findUsersByTweetIdAndUserIdOrderByCreatedAtDesc(String tweetId, String userId);

--- a/src/main/java/clone/twitter/repository/LikeTweetRepository.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetRepository.java
@@ -1,0 +1,17 @@
+package clone.twitter.repository;
+
+import clone.twitter.domain.LikeTweet;
+import clone.twitter.domain.User;
+import java.util.List;
+
+public interface LikeTweetRepository {
+    void save(LikeTweet likeTweet);
+
+    void deleteByTweetIdAndUserId(String tweetId, String userId);
+
+    Integer existsByTweetIdAndUserId(String tweetId, String userId);
+
+    List<User> findUsersByTweetIdOrderByCreatedAtDesc(String tweetId);
+
+    List<User> findUsersByTweetIdAndUserIdOrderByCreatedAtDesc(String tweetId, String userId);
+}

--- a/src/main/java/clone/twitter/repository/LikeTweetRepositoryV1.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetRepositoryV1.java
@@ -37,17 +37,6 @@ public class LikeTweetRepositoryV1 implements LikeTweetRepository {
     }
 
     /**
-     * 특정 좋아요 정보가 DB에 존재하는지 확인하고 결과값(존재하지 않을 시 0, 존재할 시 1)을 반환합니다.
-     * @param tweetId 좋아요의 타겟 트윗 id
-     * @param userId 타겟 트윗에 좋아요를 표시한 유저 id
-     * @return 좋아요 정보가 존재하지 않을 시 0, 존재할 시 1 반환
-     */
-    @Override
-    public Integer existsByTweetIdAndUserId(String tweetId, String userId) {
-        return likeTweetMapper.isLikedTweet(tweetId, userId);
-    }
-
-    /**
      * 특정 트윗에 좋아요를 표시한 유저들의 정보를 한계설정값의 수 만큼 조회합니다. 유저목록 pagination의 진입 단계입니다.
      * @param tweetId 좋아요의 타겟 트윗 id
      * @return 특정 트윗에 좋아요를 표시한 유저 정보 목록

--- a/src/main/java/clone/twitter/repository/LikeTweetRepositoryV1.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetRepositoryV1.java
@@ -12,33 +12,69 @@ import org.springframework.stereotype.Repository;
 public class LikeTweetRepositoryV1 implements LikeTweetRepository {
     private final LikeTweetMapper likeTweetMapper;
 
+    /**
+     * 특정 트윗에 좋아요를 표시 유저목록을 조회할 시 1회에 불러올 수 있는 유저 정보의 수 한계설정값
+     */
     private static final int USER_LOAD_LIMIT = 3;
 
+    /**
+     * 타겟 트윗에 대한 특정 유저의 좋아요 정보를 저장합니다.
+     * @param likeTweet 트윗의 id, 유저의 id 등 좋아요 관련 정보를 담은 객체
+     */
     @Override
     public void save(LikeTweet likeTweet) {
         likeTweetMapper.likeTweet(likeTweet);
     }
 
+    /**
+     * 특정 트윗에 대한 특정 유저의 좋아요 정보를 삭제합니다.
+     * @param tweetId 좋아요의 타겟 트윗 id
+     * @param userId 타겟 트윗에 좋아요를 표시한 유저 id
+     */
     @Override
     public void deleteByTweetIdAndUserId(String tweetId, String userId) {
         likeTweetMapper.unlikeTweet(tweetId, userId);
     }
 
+    /**
+     * 특정 좋아요 정보가 DB에 존재하는지 확인하고 결과값(존재하지 않을 시 0, 존재할 시 1)을 반환합니다.
+     * @param tweetId 좋아요의 타겟 트윗 id
+     * @param userId 타겟 트윗에 좋아요를 표시한 유저 id
+     * @return 좋아요 정보가 존재하지 않을 시 0, 존재할 시 1 반환
+     */
     @Override
     public Integer existsByTweetIdAndUserId(String tweetId, String userId) {
         return likeTweetMapper.isLikedTweet(tweetId, userId);
     }
 
+    /**
+     * 특정 트윗에 좋아요를 표시한 유저들의 정보를 한계설정값의 수 만큼 조회합니다. 유저목록 pagination의 진입 단계입니다.
+     * @param tweetId 좋아요의 타겟 트윗 id
+     * @return 특정 트윗에 좋아요를 표시한 유저 정보 목록
+     */
     @Override
     public List<User> findUsersByTweetIdOrderByCreatedAtDesc(String tweetId) {
         return likeTweetMapper.findUsersLikedTweet(tweetId, USER_LOAD_LIMIT);
     }
 
+    /**
+     * 좋아요 표시 유저목록 pagination 단계 중 이전에 조회한 목록에 이어 다음 유저들의 정보를 한계설정값의 수 만큼 추가로 조회합니다.
+     * @param tweetId 좋아요의 타겟 트윗 id
+     * @param userId 이전 pagination 에서 불러온 목록 중 가장 마지막에 위치한 유저의 id
+     * @return
+     */
     @Override
     public List<User> findUsersByTweetIdAndUserIdOrderByCreatedAtDesc(String tweetId, String userId) {
         return likeTweetMapper.findMoreUsersLikedTweet(tweetId, userId, USER_LOAD_LIMIT);
     }
 
+    /**
+     * 특정 트윗에 대한 정보를 불러옵니다.
+     * @param tweetId 좋아요의 타겟 트윗 id
+     * @param userId 타겟 트윗에 좋아요를 표시한 유저 id
+     * @return
+     * @deprecated 테스트 전용 메서드
+     */
     @Deprecated
     public Optional<LikeTweet> findLikeTweet(String tweetId, String userId) {
         return likeTweetMapper.findLikeTweet(tweetId, userId);

--- a/src/main/java/clone/twitter/repository/LikeTweetRepositoryV1.java
+++ b/src/main/java/clone/twitter/repository/LikeTweetRepositoryV1.java
@@ -1,0 +1,46 @@
+package clone.twitter.repository;
+
+import clone.twitter.domain.LikeTweet;
+import clone.twitter.domain.User;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class LikeTweetRepositoryV1 implements LikeTweetRepository {
+    private final LikeTweetMapper likeTweetMapper;
+
+    private static final int USER_LOAD_LIMIT = 3;
+
+    @Override
+    public void save(LikeTweet likeTweet) {
+        likeTweetMapper.likeTweet(likeTweet);
+    }
+
+    @Override
+    public void deleteByTweetIdAndUserId(String tweetId, String userId) {
+        likeTweetMapper.unlikeTweet(tweetId, userId);
+    }
+
+    @Override
+    public Integer existsByTweetIdAndUserId(String tweetId, String userId) {
+        return likeTweetMapper.isLikedTweet(tweetId, userId);
+    }
+
+    @Override
+    public List<User> findUsersByTweetIdOrderByCreatedAtDesc(String tweetId) {
+        return likeTweetMapper.findUsersLikedTweet(tweetId, USER_LOAD_LIMIT);
+    }
+
+    @Override
+    public List<User> findUsersByTweetIdAndUserIdOrderByCreatedAtDesc(String tweetId, String userId) {
+        return likeTweetMapper.findMoreUsersLikedTweet(tweetId, userId, USER_LOAD_LIMIT);
+    }
+
+    @Deprecated
+    public Optional<LikeTweet> findLikeTweet(String tweetId, String userId) {
+        return likeTweetMapper.findLikeTweet(tweetId, userId);
+    }
+}

--- a/src/main/resources/mapper/LikeTweetMapper.xml
+++ b/src/main/resources/mapper/LikeTweetMapper.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="clone.twitter.repository.LikeTweetMapper">
+  <insert id="likeTweet">
+    INSERT INTO like_tweet (tweet_id, user_id, created_at)
+    VALUES (#{tweetId}, #{userId}, #{createdAt})
+  </insert>
+
+  <delete id="unlikeTweet">
+    DELETE FROM like_tweet
+    WHERE tweet_id = #{tweetId}
+    AND user_id = #{userId}
+  </delete>
+
+  <select id="isLikedTweet" resultType="Integer">
+    SELECT COUNT(*)
+    FROM like_tweet
+    WHERE tweet_id = #{tweetId}
+    AND user_id = #{userId}
+  </select>
+
+  <select id="findUsersLikedTweet" resultType="User">
+    SELECT u.*
+    FROM user u
+    JOIN like_tweet lt
+    ON u.id = lt.user_id
+    WHERE lt.tweet_id = #{tweetId}
+    ORDER BY lt.created_at DESC
+    LIMIT #{limit}
+  </select>
+
+  <select id="findMoreUsersLikedTweet" resultType="User">
+    SELECT u.*
+    FROM user u
+    JOIN like_tweet lt
+    ON u.id = lt.user_id
+    WHERE lt.tweet_id = #{tweetId}
+    AND lt.created_at &lt; (
+    SELECT created_at
+    FROM like_tweet
+    WHERE user_id = #{userId}
+    )
+    ORDER BY lt.created_at DESC
+    LIMIT #{limit}
+  </select>
+
+  <select id="findLikeTweet" resultType="LikeTweet">
+    SELECT *
+    FROM like_tweet
+    WHERE tweet_id = #{tweetId}
+    AND user_id = #{userId}
+  </select>
+</mapper>

--- a/src/main/resources/mapper/LikeTweetMapper.xml
+++ b/src/main/resources/mapper/LikeTweetMapper.xml
@@ -3,45 +3,67 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="clone.twitter.repository.LikeTweetMapper">
   <insert id="likeTweet">
-    INSERT INTO like_tweet (tweet_id, user_id, created_at)
-    VALUES (#{tweetId}, #{userId}, #{createdAt})
+    INSERT INTO
+      like_tweet (tweet_id, user_id, created_at)
+    VALUES
+      (#{tweetId}, #{userId}, #{createdAt})
   </insert>
 
   <delete id="unlikeTweet">
-    DELETE FROM like_tweet
-    WHERE tweet_id = #{tweetId}
-    AND user_id = #{userId}
+    DELETE FROM
+      like_tweet
+    WHERE
+      tweet_id = #{tweetId}
+      AND user_id = #{userId}
   </delete>
 
   <select id="findUsersLikedTweet" resultType="User">
-    SELECT u.*
-    FROM user u
-    JOIN like_tweet lt
-    ON u.id = lt.user_id
-    WHERE lt.tweet_id = #{tweetId}
-    ORDER BY lt.created_at DESC
-    LIMIT #{limit}
+    SELECT
+      u.*
+    FROM
+      user u
+    JOIN
+      like_tweet lt
+      ON u.id = lt.user_id
+    WHERE
+      lt.tweet_id = #{tweetId}
+    ORDER BY
+      lt.created_at DESC
+    LIMIT
+      #{limit}
   </select>
 
   <select id="findMoreUsersLikedTweet" resultType="User">
-    SELECT u.*
-    FROM user u
-    JOIN like_tweet lt
+    SELECT
+      u.*
+    FROM
+      user u
+    JOIN
+      like_tweet lt
     ON u.id = lt.user_id
-    WHERE lt.tweet_id = #{tweetId}
-    AND lt.created_at &lt; (
-    SELECT created_at
-    FROM like_tweet
-    WHERE user_id = #{userId}
-    )
-    ORDER BY lt.created_at DESC
-    LIMIT #{limit}
+    WHERE
+      lt.tweet_id = #{tweetId}
+      AND lt.created_at &lt; (
+        SELECT
+          created_at
+        FROM
+          like_tweet
+        WHERE
+          user_id = #{userId}
+      )
+    ORDER BY
+      lt.created_at DESC
+    LIMIT
+      #{limit}
   </select>
 
   <select id="findLikeTweet" resultType="LikeTweet">
-    SELECT *
-    FROM like_tweet
-    WHERE tweet_id = #{tweetId}
-    AND user_id = #{userId}
+    SELECT
+      *
+    FROM
+      like_tweet
+    WHERE
+      tweet_id = #{tweetId}
+      AND user_id = #{userId}
   </select>
 </mapper>

--- a/src/main/resources/mapper/LikeTweetMapper.xml
+++ b/src/main/resources/mapper/LikeTweetMapper.xml
@@ -13,13 +13,6 @@
     AND user_id = #{userId}
   </delete>
 
-  <select id="isLikedTweet" resultType="Integer">
-    SELECT COUNT(*)
-    FROM like_tweet
-    WHERE tweet_id = #{tweetId}
-    AND user_id = #{userId}
-  </select>
-
   <select id="findUsersLikedTweet" resultType="User">
     SELECT u.*
     FROM user u

--- a/src/test/java/clone/twitter/domain/LikeTweetRepositoryTest.java
+++ b/src/test/java/clone/twitter/domain/LikeTweetRepositoryTest.java
@@ -139,51 +139,6 @@ public class LikeTweetRepositoryTest {
     }
 
     @Test
-    void existsByTweetIdAndUserId() {
-        // given
-        // 유저 객체 생성
-        User user1 = new User("user1", "user1@gmail.com", "AAAAAA", "user1ProfileName", LocalDate.of(1991, 1, 1));
-        User user2 = new User("user2", "user2@gmail.com", "BBBBBB", "user2ProfileName", LocalDate.of(1992, 2, 2));
-
-        // 유저 객체 정보 DB 저장
-        userRepository.save(user1);
-        userRepository.save(user2);
-
-        // 트윗 객체 생성
-        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
-        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
-
-        // 유저 객체 정보 DB에 저장
-        tweetRepository.save(tweet1);
-        tweetRepository.save(tweet2);
-
-        // 좋아요-트윗 객체 생성: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
-        LikeTweet likeTweet1 = new LikeTweet(tweet1.getId(), user2.getId());
-        LikeTweet likeTweet2 = new LikeTweet(tweet2.getId(), user1.getId());
-
-        // when
-        // 좋아요-트윗 객체 정보 DB에 저장
-        likeTweetRepository.save(likeTweet1);
-        likeTweetRepository.save(likeTweet2);
-
-        // 좋아요-트윗 정보 DB 조회, 결과를 객체에 할당
-        Optional<LikeTweet> foundLikeTweet1 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet1.getId(), user2.getId());
-        Optional<LikeTweet> foundLikeTweet2 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet2.getId(), user1.getId());
-
-        // DB에 저장된 총 2개의 좋아요-트윗 정보 중 1개만 삭제
-        likeTweetRepository.deleteByTweetIdAndUserId(tweet1.getId(), user2.getId());
-
-        // then
-        // 좋아요-트윗 DB 정보 존재 여부 조회, 결과를 객체에 할당
-        Integer isExistByTweetIdAndUserId1 = likeTweetRepository.existsByTweetIdAndUserId(tweet1.getId(), user2.getId());
-        Integer isExistByTweetIdAndUserId2 = likeTweetRepository.existsByTweetIdAndUserId(tweet2.getId(), user1.getId());
-
-        // 좋아요-트윗 DB 정보 존재 여부 조회 결과 검증: user2 -> tweet1은 삭제되었으므로 0 반환, user1 -> tweet2은 삭제하지 않았으므로 1이 반환되어야 함
-        Assertions.assertThat(isExistByTweetIdAndUserId1).isEqualTo(0);
-        Assertions.assertThat(isExistByTweetIdAndUserId2).isEqualTo(1);
-    }
-
-    @Test
     void findUsersByTweetIdOrderByCreatedAtDesc() {
         // given
         // 유저 객체 생성

--- a/src/test/java/clone/twitter/domain/LikeTweetRepositoryTest.java
+++ b/src/test/java/clone/twitter/domain/LikeTweetRepositoryTest.java
@@ -1,0 +1,298 @@
+package clone.twitter.domain;
+
+import clone.twitter.repository.LikeTweetRepository;
+import clone.twitter.repository.LikeTweetRepositoryV1;
+import clone.twitter.repository.TweetRepository;
+import clone.twitter.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+public class LikeTweetRepositoryTest {
+    @Autowired
+    PlatformTransactionManager transactionManager;
+
+    TransactionStatus status;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    TweetRepository tweetRepository;
+
+    @Autowired
+    LikeTweetRepository likeTweetRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+    }
+
+    @AfterEach
+    void afterEach() {
+        transactionManager.rollback(status);
+    }
+
+    @Test
+    void save() {
+        // given
+        // 유저 객체 생성
+        User user1 = new User("user1", "user1@gmail.com", "AAAAAA", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "BBBBBB", "user2ProfileName", LocalDate.of(1992, 2, 2));
+
+        // 유저 객체 정보 DB 저장
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        // 트윗 객체 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저 객체 정보 DB 저장
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet2);
+
+        // 좋아요-트윗 객체 생성: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
+        LikeTweet likeTweet1 = new LikeTweet(tweet1.getId(), user2.getId());
+        LikeTweet likeTweet2 = new LikeTweet(tweet2.getId(), user1.getId());
+
+        // when
+        // 좋아요-트윗 객체 정보 DB 저장
+        likeTweetRepository.save(likeTweet1);
+        likeTweetRepository.save(likeTweet2);
+
+        // 좋아요-트윗 DB 정보 조회
+        Optional<LikeTweet> foundLikeTweet1 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet1.getId(), user2.getId());
+        Optional<LikeTweet> foundLikeTweet2 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet2.getId(), user1.getId());
+
+        // then
+        // 좋아요-트윗 DB 정보 조회 결과 검증: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
+        Assertions.assertThat(foundLikeTweet1).isEqualTo(Optional.of(likeTweet1));
+        Assertions.assertThat(foundLikeTweet2).isEqualTo(Optional.of(likeTweet2));
+    }
+
+    @Test
+    void deleteByTweetIdAndUserId() {
+        // given
+        // 유저 객체 생성
+        User user1 = new User("user1", "user1@gmail.com", "AAAAAA", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "BBBBBB", "user2ProfileName", LocalDate.of(1992, 2, 2));
+
+        // 유저 객체 정보 DB 저장
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        // 트윗 객체 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저 객체 정보 DB에 저장
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet2);
+
+        // 좋아요-트윗 객체 생성: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
+        LikeTweet likeTweet1 = new LikeTweet(tweet1.getId(), user2.getId());
+        LikeTweet likeTweet2 = new LikeTweet(tweet2.getId(), user1.getId());
+
+        // when
+        // 좋아요-트윗 객체 정보 DB에 저장
+        likeTweetRepository.save(likeTweet1);
+        likeTweetRepository.save(likeTweet2);
+
+        // 좋아요-트윗 정보 DB 조회, 결과를 객체에 할당
+        Optional<LikeTweet> foundLikeTweet1 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet1.getId(), user2.getId());
+        Optional<LikeTweet> foundLikeTweet2 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet2.getId(), user1.getId());
+
+        // then
+        // 좋아요-트윗 DB 정보 조회 결과 검증: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
+        Assertions.assertThat(foundLikeTweet1).isEqualTo(Optional.of(likeTweet1));
+        Assertions.assertThat(foundLikeTweet2).isEqualTo(Optional.of(likeTweet2));
+
+        // 좋아요-트윗 DB 정보 DB 삭제: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
+        likeTweetRepository.deleteByTweetIdAndUserId(tweet1.getId(), user2.getId());
+        likeTweetRepository.deleteByTweetIdAndUserId(tweet2.getId(), user1.getId());
+
+        // 좋아요-트윗 DB 정보 DB 삭제 후 DB 조회, 결과를 객체에 할당
+        foundLikeTweet1 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet1.getId(), user2.getId());
+        foundLikeTweet2 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet2.getId(), user1.getId());
+
+        // (좋아요-트윗 DB 정보 삭제 후)DB 조회 결과 검증: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요 두 건 모두 삭제되었으므로 빈 객체가 반환되어야 함
+        Assertions.assertThat(foundLikeTweet1).isEmpty();
+        Assertions.assertThat(foundLikeTweet2).isEmpty();
+    }
+
+    @Test
+    void existsByTweetIdAndUserId() {
+        // given
+        // 유저 객체 생성
+        User user1 = new User("user1", "user1@gmail.com", "AAAAAA", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "BBBBBB", "user2ProfileName", LocalDate.of(1992, 2, 2));
+
+        // 유저 객체 정보 DB 저장
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        // 트윗 객체 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+
+        // 유저 객체 정보 DB에 저장
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet2);
+
+        // 좋아요-트윗 객체 생성: user2 -> tweet1 좋아요, user1 -> tweet2 좋아요
+        LikeTweet likeTweet1 = new LikeTweet(tweet1.getId(), user2.getId());
+        LikeTweet likeTweet2 = new LikeTweet(tweet2.getId(), user1.getId());
+
+        // when
+        // 좋아요-트윗 객체 정보 DB에 저장
+        likeTweetRepository.save(likeTweet1);
+        likeTweetRepository.save(likeTweet2);
+
+        // 좋아요-트윗 정보 DB 조회, 결과를 객체에 할당
+        Optional<LikeTweet> foundLikeTweet1 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet1.getId(), user2.getId());
+        Optional<LikeTweet> foundLikeTweet2 = ((LikeTweetRepositoryV1) likeTweetRepository).findLikeTweet(tweet2.getId(), user1.getId());
+
+        // DB에 저장된 총 2개의 좋아요-트윗 정보 중 1개만 삭제
+        likeTweetRepository.deleteByTweetIdAndUserId(tweet1.getId(), user2.getId());
+
+        // then
+        // 좋아요-트윗 DB 정보 존재 여부 조회, 결과를 객체에 할당
+        Integer isExistByTweetIdAndUserId1 = likeTweetRepository.existsByTweetIdAndUserId(tweet1.getId(), user2.getId());
+        Integer isExistByTweetIdAndUserId2 = likeTweetRepository.existsByTweetIdAndUserId(tweet2.getId(), user1.getId());
+
+        // 좋아요-트윗 DB 정보 존재 여부 조회 결과 검증: user2 -> tweet1은 삭제되었으므로 0 반환, user1 -> tweet2은 삭제하지 않았으므로 1이 반환되어야 함
+        Assertions.assertThat(isExistByTweetIdAndUserId1).isEqualTo(0);
+        Assertions.assertThat(isExistByTweetIdAndUserId2).isEqualTo(1);
+    }
+
+    @Test
+    void findUsersByTweetIdOrderByCreatedAtDesc() {
+        // given
+        // 유저 객체 생성
+        User user1 = new User("user1", "user1@gmail.com", "password1", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "password2", "user2ProfileName", LocalDate.of(1991, 1, 2));
+        User user3 = new User("user3", "user3@gmail.com", "password3", "user3ProfileName", LocalDate.of(1991, 1, 3));
+        User user4 = new User("user4", "user4@gmail.com", "password4", "user4ProfileName", LocalDate.of(1991, 1, 4));
+        User user5 = new User("user5", "user5@gmail.com", "password5", "user5ProfileName", LocalDate.of(1991, 1, 5));
+        User user6 = new User("user6", "user6@gmail.com", "password6", "user6ProfileName", LocalDate.of(1991, 1, 6));
+        User user7 = new User("user7", "user7@gmail.com", "password7", "user7ProfileName", LocalDate.of(1991, 1, 7));
+
+        // 유저 객체 정보 DB 저장
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+        userRepository.save(user5);
+        userRepository.save(user6);
+        userRepository.save(user7);
+
+        // 트윗 객체 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        Tweet tweet2 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user2", user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+
+        // 트윗 객체 정보 DB에 저장
+        tweetRepository.save(tweet1);
+        tweetRepository.save(tweet2);
+
+        // 좋아요-트윗 객체 생성
+        LikeTweet likeTweet1 = new LikeTweet(tweet1.getId(), user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet2 = new LikeTweet(tweet1.getId(), user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet3 = new LikeTweet(tweet1.getId(), user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 3).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet4 = new LikeTweet(tweet1.getId(), user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 4).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet5 = new LikeTweet(tweet1.getId(), user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 5).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet6 = new LikeTweet(tweet2.getId(), user6.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 6).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet7 = new LikeTweet(tweet2.getId(), user7.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 7).truncatedTo(ChronoUnit.SECONDS));
+
+        // when
+        // 좋아요-트윗 객체 정보 DB에 저장
+        likeTweetRepository.save(likeTweet1);
+        likeTweetRepository.save(likeTweet2);
+        likeTweetRepository.save(likeTweet3);
+        likeTweetRepository.save(likeTweet4);
+        likeTweetRepository.save(likeTweet5);
+        likeTweetRepository.save(likeTweet6);
+        likeTweetRepository.save(likeTweet7);
+
+        // then
+        // 특정 트윗에 좋아요를 누른 유저들의 정보를 pagination limit 갯수 만큼 좋아요 생성 시간 내림차순으로 조회, 결과를 객체에 할당
+        List<User> usersByTweetIdOrderByCreatedAtDescForTweet1 = likeTweetRepository.findUsersByTweetIdOrderByCreatedAtDesc(tweet1.getId());
+        List<User> usersByTweetIdOrderByCreatedAtDescForTweet2 = likeTweetRepository.findUsersByTweetIdOrderByCreatedAtDesc(tweet2.getId());
+
+        // 특정 트윗에 좋아요를 누른 유저들의 정보 검증1: tweet1에 좋아요를 누른 유저들의 정보는 user5, user4, user3 순서로 조회되어야 함
+        Assertions.assertThat(usersByTweetIdOrderByCreatedAtDescForTweet1).containsExactly(user5, user4, user3);
+        // 특정 트윗에 좋아요를 누른 유저들의 정보 검증2: tweet2에 좋아요를 누른 유저들의 정보는 user5, user4, user3 순서로 조회되어야 함
+        Assertions.assertThat(usersByTweetIdOrderByCreatedAtDescForTweet2).containsExactly(user7, user6);
+    }
+
+    @Test
+    void findUsersByTweetIdAndUserIdOrderByCreatedAtDesc() {
+        // given
+        // 유저 객체 생성
+        User user1 = new User("user1", "user1@gmail.com", "password1", "user1ProfileName", LocalDate.of(1991, 1, 1));
+        User user2 = new User("user2", "user2@gmail.com", "password2", "user2ProfileName", LocalDate.of(1991, 1, 2));
+        User user3 = new User("user3", "user3@gmail.com", "password3", "user3ProfileName", LocalDate.of(1991, 1, 3));
+        User user4 = new User("user4", "user4@gmail.com", "password4", "user4ProfileName", LocalDate.of(1991, 1, 4));
+        User user5 = new User("user5", "user5@gmail.com", "password5", "user5ProfileName", LocalDate.of(1991, 1, 5));
+        User user6 = new User("user6", "user6@gmail.com", "password6", "user6ProfileName", LocalDate.of(1991, 1, 6));
+        User user7 = new User("user7", "user7@gmail.com", "password7", "user7ProfileName", LocalDate.of(1991, 1, 7));
+
+        // 유저 객체 정보 DB 저장
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+        userRepository.save(user5);
+        userRepository.save(user6);
+        userRepository.save(user7);
+
+        // 트윗 객체 생성
+        Tweet tweet1 = new Tweet(UUID.randomUUID().toString(), "haro, this be tweet of user1", user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+
+        // 트윗 객체 정보 DB 저장
+        tweetRepository.save(tweet1);
+
+        // 좋아요-트윗 객체 생성
+        LikeTweet likeTweet1 = new LikeTweet(tweet1.getId(), user1.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 1).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet2 = new LikeTweet(tweet1.getId(), user2.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 2).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet3 = new LikeTweet(tweet1.getId(), user3.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 3).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet4 = new LikeTweet(tweet1.getId(), user4.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 4).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet5 = new LikeTweet(tweet1.getId(), user5.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 5).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet6 = new LikeTweet(tweet1.getId(), user6.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 6).truncatedTo(ChronoUnit.SECONDS));
+        LikeTweet likeTweet7 = new LikeTweet(tweet1.getId(), user7.getId(), LocalDateTime.of(2023, 1, 1, 1, 1, 7).truncatedTo(ChronoUnit.SECONDS));
+
+        // when
+        // 좋아요-트윗 객체 정보 DB 저장
+        likeTweetRepository.save(likeTweet1);
+        likeTweetRepository.save(likeTweet2);
+        likeTweetRepository.save(likeTweet3);
+        likeTweetRepository.save(likeTweet4);
+        likeTweetRepository.save(likeTweet5);
+        likeTweetRepository.save(likeTweet6);
+        likeTweetRepository.save(likeTweet7);
+
+        // then
+        // 특정 트윗에 좋아요를 누른 유저들의 최초 정보 목록 조회 후(최신순으로 user7, user6, user5), 스크롤 다운 시 맨 마지막에 있던 user5의 좋아요 생성시간을 기준으로 생성시간 내림차순으로 유저 추가 조회, 유저 정보목록을 반환 받아 결과정보 객체에 할당
+        List<User> moreUsersByTweetIdOrderByCreatedAtDesc = likeTweetRepository.findUsersByTweetIdAndUserIdOrderByCreatedAtDesc(tweet1.getId(), user5.getId());
+
+        // 특정 트윗에 좋아요를 누른 유저들을 추가 조회한 후 유저 정보 검증: tweet1에 좋아요를 누른 다음 유저들의 정보는 user4, user3, user2 순서로 조회되어야 함
+        Assertions.assertThat(moreUsersByTweetIdOrderByCreatedAtDesc).containsExactly(user4, user3, user2);
+    }
+}


### PR DESCRIPTION
## 최신 현황
- 기능 구현
  - 좋아요 정보 DB 저장
  - 좋아요 정보 DB 삭제
  - 좋아요 정보 DB 저장 여부 확인
  - 특정 트윗에 좋아요를 표시한 유저 목록 시간내림차순 조회 pagination
- 각 기능 테스트 완료

### 초기 정보
- like-tweet api에 필요한 기초 DB 접근 layer를 구현하고 SQL 매핑 정보를 작성하였습니다.
- 혹시 이후에 JPA로도 유연히 변경할 수 있도록 repository layer를 인터페이스와 구현부로 나누어 구현하였습니다.
- 각 트윗에 대한 좋아요 카운트는 tweet 레코드의 개별 필드에 추가하는 방식 고민 -> 이후 버전에 추가
- 추가 고민 포인트: #14 