### PR TITLE
[#80] Redis Cluster 적용 설정 추가

### DIFF
--- a/src/main/java/clone/twitter/config/RedisClusterProperties.java
+++ b/src/main/java/clone/twitter/config/RedisClusterProperties.java
@@ -1,0 +1,20 @@
+package clone.twitter.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "spring.redis.cluster")
+public class RedisClusterProperties {
+
+    private List<String> nodes;
+
+    public List<String> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<String> nodes) {
+        this.nodes = nodes;
+    }
+}

--- a/src/main/java/clone/twitter/config/RedisConfig.java
+++ b/src/main/java/clone/twitter/config/RedisConfig.java
@@ -2,16 +2,20 @@ package clone.twitter.config;
 
 import static clone.twitter.util.CacheConstant.CACHE_DURATION_IN_HOUR;
 
+import io.lettuce.core.ReadFrom;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -19,6 +23,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
 
     @Value("${spring.redis.session.host}")
@@ -38,6 +43,8 @@ public class RedisConfig {
 
     @Value("${spring.redis.fan-out.password}")
     private String redisFanOutPassword;
+
+    private final RedisClusterProperties clusterProperties;
 
     // spring-session-data-redis 의존성 추가시 해당 라이브러리가 "redisConnectionFactory"라는
     // 이름으로 빈을 자동 등록하게 됩니다. 여기에서 다른 redis connection factory들과 이름 혼동이
@@ -66,6 +73,19 @@ public class RedisConfig {
         redisStandaloneConfiguration.setPassword(redisFanOutPassword);
 
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisConnectionFactory redisFanOutClusterConnectionFactory() {
+
+        LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder()
+            .readFrom(ReadFrom.REPLICA_PREFERRED)
+            .build();
+
+        RedisClusterConfiguration clusterConfiguration
+            = new RedisClusterConfiguration(clusterProperties.getNodes());
+
+        return new LettuceConnectionFactory(clusterConfiguration, clientConfiguration);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,14 @@ spring:
       host:
       port:
       password:
+    cluster:
+      nodes:
+        - host1:port
+        - host2:port
+        - host3:port
+        - host4:port
+        - host5:port
+        - host6:port
 
 logging:
   level:


### PR DESCRIPTION
- 고가용성(failover)과 쓰기 성능 개선을 위한 Redis Cluster 적용 설정 추가
- 샤드(각 master 1개 + replica 1개로 구성) 3개 고려 설정
